### PR TITLE
Added more skippable types from wikipedia docs

### DIFF
--- a/src/IcnsParser.php
+++ b/src/IcnsParser.php
@@ -27,7 +27,7 @@ final class IcnsParser
                     $stream->readUint32() - 8; //size
                     $read += 8;
                 }
-            } elseif (\in_array($type, ['icnV', 'name', 'info'])) {
+            } elseif (\in_array($type, ['icnV', 'name', 'info', 'sbtp', 'slct', 'ýÙ/¨'])) {
                 $stream->skip($length);
             } else {
                 $elements[] = new IcnsElement(


### PR DESCRIPTION
According to wikipedia, there are a few more "not-useful in this context" types that can be skipped.